### PR TITLE
Update airbnb.swiftformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -2256,12 +2256,80 @@ _You can enable the following settings in Xcode by running [this script](resourc
 ## Amendments
 
 - ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapconditionalbodies))`--rules wrapConditionalBodies`[![SwiftFormat: wrapConditionalBodies](https://img.shields.io/badge/SwiftFormat-wrapConditionalBodies-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapconditionalbodies)
+  <details>
+
+  ```swift
+  // WRONG
+  guard let foo = bar else { return baz }
+
+  // RIGHT
+  guard let foo = bar else {
+    return baz
+  }
+  ```
+
+  </details>
 
 - ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapenumcases))`--rules wrapEnumCases`[![SwiftFormat: wrapEnumCases](https://img.shields.io/badge/SwiftFormat-wrapEnumCases-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapenumcases)
+  <details>
+
+  ```swift
+  // WRONG
+  enum Foo { 
+    case bar, baz
+  }
+
+  // RIGHT
+  enum Foo {
+    case bar
+    case baz
+  }
+  ```
+
+  </details>
 
 - ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapmultilinestatementbraces))`--rules wrapMultilineStatementBraces`[![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapmultilinestatementbraces)
+  <details>
+
+    ```swift
+    // WRONG
+    if 
+      foo, 
+      bar { 
+      // ...
+    }
+
+    // RIGHT
+    if 
+      foo, 
+      bar
+    {
+      // ...
+    }
+    ```
+
+  </details>
 
 - ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapswitchcases))`--rules wrapSwitchCases`[![SwiftFormat: wrapSwitchCases](https://img.shields.io/badge/SwiftFormat-wrapSwitchCases-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapswitchcases)
+  <details>
+
+    ```swift
+    // WRONG
+    switch foo { 
+    case .bar, .baz:
+      break
+    }
+
+    // RIGHT
+    switch foo {
+    case .bar,
+         .baz:
+      break
+    }
+    ```
+
+    </details>
+
 
 ## Xcode Formatting
 

--- a/README.md
+++ b/README.md
@@ -2254,8 +2254,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
 **[⬆ back to top](#table-of-contents)**
 
 ## Amendments
+* <a id='wrap-conditional-bodies'></a>(<a href='#wrap-conditional-bodies'>link</a>) **Wrap the bodies of inline conditional statements onto a new line.** This increasses clarity.[![SwiftFormat: wrapConditionalBodies](https://img.shields.io/badge/SwiftFormat-wrapConditionalBodies-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapconditionalbodies)
 
-- ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapconditionalbodies))`--rules wrapConditionalBodies`[![SwiftFormat: wrapConditionalBodies](https://img.shields.io/badge/SwiftFormat-wrapConditionalBodies-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapconditionalbodies)
   <details>
 
   ```swift
@@ -2270,7 +2270,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-- ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapenumcases))`--rules wrapEnumCases`[![SwiftFormat: wrapEnumCases](https://img.shields.io/badge/SwiftFormat-wrapEnumCases-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapenumcases)
+* <a id='wrap-enum-cases'></a>(<a href='#wrap-enum-cases'>link</a>) **Write one enum case per line.** This increasses clarity.[![SwiftFormat: wrapEnumCases](https://img.shields.io/badge/SwiftFormat-wrapEnumCases-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapenumcases)
+
   <details>
 
   ```swift
@@ -2288,54 +2289,30 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-- ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapmultilinestatementbraces))`--rules wrapMultilineStatementBraces`[![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapmultilinestatementbraces)
+* <a id='wrap-switch-cases'></a>(<a href='#wrap-switch-cases'>link</a>) **Write one switch case per line.** This increasses clarity.[![SwiftFormat: wrapSwitchCases](https://img.shields.io/badge/SwiftFormat-wrapSwitchCases-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapswitchcases)
+
   <details>
 
-    ```swift
-    // WRONG
-    if 
-      foo, 
-      bar { 
-      // ...
-    }
+  ```swift
+  // WRONG
+  enum Foo { 
+    case bar, baz
+  }
 
-    // RIGHT
-    if 
-      foo, 
-      bar
-    {
-      // ...
-    }
-    ```
+  // RIGHT
+  enum Foo {
+    case bar
+    case baz
+  }
+  ```
 
   </details>
-
-- ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapswitchcases))`--rules wrapSwitchCases`[![SwiftFormat: wrapSwitchCases](https://img.shields.io/badge/SwiftFormat-wrapSwitchCases-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapswitchcases)
-  <details>
-
-    ```swift
-    // WRONG
-    switch foo { 
-    case .bar, .baz:
-      break
-    }
-
-    // RIGHT
-    switch foo {
-    case .bar,
-         .baz:
-      break
-    }
-    ```
-
-    </details>
-
 
 ## Xcode Formatting
 
 _You can enable the following settings in Xcode by running [this script](resources/xcode_settings_slumber_group.bash), e.g. as part of a "Run Script" build phase._
 
-* <a id='120-column-width'></a>(<a href='#120-column-width'>link</a>) **Each line should have a maximum column width of 120 characters.**
+* <a id='130-column-width'></a>(<a href='#130-column-width'>link</a>) **Each line should have a maximum column width of 130 characters.**
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -2255,8 +2255,14 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 ## Amendments
 
-We encourage you to fork this guide and change the rules to fit your team’s style guide. Below, you may list some amendments to the style guide. This allows you to periodically update your style guide without having to deal with merge conflicts.
-     
+- ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapconditionalbodies))`--rules wrapConditionalBodies`[![SwiftFormat: wrapConditionalBodies](https://img.shields.io/badge/SwiftFormat-wrapConditionalBodies-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapconditionalbodies)
+
+- ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapenumcases))`--rules wrapEnumCases`[![SwiftFormat: wrapEnumCases](https://img.shields.io/badge/SwiftFormat-wrapEnumCases-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapenumcases)
+
+- ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapmultilinestatementbraces))`--rules wrapMultilineStatementBraces`[![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapmultilinestatementbraces)
+
+- ([link](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapswitchcases))`--rules wrapSwitchCases`[![SwiftFormat: wrapSwitchCases](https://img.shields.io/badge/SwiftFormat-wrapSwitchCases-7B0051)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapswitchcases)
+
 ## Xcode Formatting
 
 _You can enable the following settings in Xcode by running [this script](resources/xcode_settings_slumber_group.bash), e.g. as part of a "Run Script" build phase._

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -59,6 +59,10 @@
 --rules wrap
 --rules wrapArguments
 --rules wrapAttributes
+--rules wrapConditionalBodies
+--rules wrapEnumCases
+--rules wrapMultilineStatementBraces
+--rules wrapSwitchCases
 --rules braces
 --rules redundantClosure
 --rules redundantInit

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -61,7 +61,6 @@
 --rules wrapAttributes
 --rules wrapConditionalBodies
 --rules wrapEnumCases
---rules wrapMultilineStatementBraces
 --rules wrapSwitchCases
 --rules braces
 --rules redundantClosure

--- a/resources/xcode_settings_slumber_group.bash
+++ b/resources/xcode_settings_slumber_group.bash
@@ -8,4 +8,4 @@ defaults write com.apple.dt.Xcode DVTTextEditorTrimWhitespaceOnlyLines -bool YES
 defaults write com.apple.dt.Xcode DVTTextIndentTabWidth -int 4
 defaults write com.apple.dt.Xcode DVTTextIndentWidth -int 4
 
-defaults write com.apple.dt.Xcode DVTTextPageGuideLocation -int 120
+defaults write com.apple.dt.Xcode DVTTextPageGuideLocation -int 130


### PR DESCRIPTION
#### Summary

Add the following rules:
- [wrapMultilineStatementBraces](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapmultilinestatementbraces)
- [wrapConditionalBodies](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapconditionalbodies)
- [wrapEnumCases](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapenumcases)
- [wrapSwitchCases](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapswitchcases)

#### Reasoning
- Without the `wrapMultilineStatementBraces` rule, I feel it makes it hard to see where the conditions / function parameters end and where the action starts. Also, this rule is formulated in AirBnB's style guide, but it seems to be missing from their `.swiftformat` file.
See this example, where it is hard to see where the `if` conditions end and where the action starts:
    - with the current setting
![Capture d’écran 2022-04-14 à 09 57 11](https://user-images.githubusercontent.com/75146312/163406655-07823056-3704-47f5-b89b-149a14130015.png)
    - with the `--wrapMultilineStatementBraces` rule
![Capture d’écran 2022-04-14 à 09 57 25](https://user-images.githubusercontent.com/75146312/163406697-164cbcb6-14e5-4e92-bedf-e6c4cece5d24.png)

- The other 3 rules (`wrapConditionalBodies`, `wrapEnumCases`, `wrapSwitchCases`) enforce what we already have in our guidelines (see the examples in the doc linked above for each one of them), so I feel it would be a good idea to include them so we don't have to think about it.

_Please react with 👍/👎 if you agree or disagree with this proposal._
