### PR TITLE
Update swiftlint.yml

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -26,6 +26,7 @@ only_rules:
 excluded:
   - Carthage
   - Pods
+  - ../Pods
   
 colon:
   apply_to_dictionaries: false


### PR DESCRIPTION
Workaround for a new behavior in which SwiftLint searches for exclusions from the .yml location and has a bug in which exclusion wildcards don't work.