### PR TITLE
Update swiftlint.yml

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -27,6 +27,8 @@ excluded:
   - Carthage
   - Pods
   - ../Pods
+  - ../../Pods
+  - ../../../Pods  
   
 colon:
   apply_to_dictionaries: false


### PR DESCRIPTION
Due to previously-mentioned **SwiftLint** bug + feature change where exclusions can't use wildcards and have to be referenced relative to the location of this `yml`, a few different possible `Pod` locations have to be added here.