### PR TITLE
Remove swiftlint file and body length warnings

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -17,10 +17,8 @@ only_rules:
   # Slumber Group Rules
   - attributes
   - cyclomatic_complexity
-  - file_length
   - function_body_length
   - function_parameter_count
-  - type_body_length
   - type_name
 
 excluded:
@@ -37,19 +35,12 @@ indentation: 4
     
 cyclomatic_complexity:
   warning: 25
-  
-file_length:
-  warning: 1000
-  ignore_comment_only_lines: true
 
 function_body_length:
   warning: 300
 
 function_parameter_count:
   warning: 6
-
-type_body_length:
-  warning: 300
 
 type_name:
   max_length:


### PR DESCRIPTION
I think we can make a linter change that removes warnings without waiting, since it won't provoke any new work for anyone.