### PR TITLE
Chore/turn off unused arg param

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -41,6 +41,7 @@
 --rules anyObjectProtocol
 --rules blankLinesBetweenScopes
 --rules consecutiveSpaces
+--rules consecutiveBreakLines
 --rules duplicateImports
 --rules extensionAccessControl
 --rules hoistPatternLet
@@ -73,7 +74,6 @@
 --rules redundantInit
 --rules redundantVoidReturnType
 --rules redundantOptionalBinding
---rules unusedArguments
 --rules spaceInsideBrackets
 --rules spaceInsideBraces
 --rules spaceAroundBraces

--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -14,7 +14,6 @@ only_rules:
   - void_return
   - custom_rules
   # Slumber Group Rules
-  - attributes
   - cyclomatic_complexity
   - function_body_length
   - function_parameter_count

--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -11,7 +11,6 @@ only_rules:
   - return_arrow_whitespace
   - trailing_newline
   - unused_optional_binding
-  - vertical_whitespace
   - void_return
   - custom_rules
   # Slumber Group Rules


### PR DESCRIPTION
#### Summary

As requested, I made the following changes:

## SwiftFormat:

Added:

**consecutiveBreakLines** (collapses multiple linebreaks into one)

Removed:

**unusedArguments** (unused arguments now OK)

## SwiftLint:

Removed:

**vertical_whitespace** (better as a format)
**attributes** (rule too high-maintenance)

#### Reasoning

Rules which create more work than they remove aren't helping us.
