### PR TITLE
Reverting to swift 5.6 version

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -4,7 +4,7 @@
 --exclude **/Pods,**/fastlane,**/Submodules
 
 # options
---swiftversion 5.8 # This change is provisional, and may need to be decremented when we roll it out
+--swiftversion 5.6
 --self remove # redundantSelf
 --importgrouping testable-bottom # sortedImports
 --commas always # trailingCommas


### PR DESCRIPTION
#### Summary

Huxley on Slack: 

> I think we’re all on Xcode 14.2 currently, with Swift 5.7.2 bundled as the main development IDE/language.  We can schedule an upgrade to Xcode 14.3 with Swift 5.8 as the main development IDE/language in mid-August.

Since we will make that move mid-August, how about we keep it as 5.6 until then?

#### Reasoning

This way we would have one more month to do the transition/resolve issues that we need xcode 13 for

_Please react with 👍/👎 if you agree or disagree with this proposal._
