### PR TITLE
Fix - Changing from error to warning print statements severity

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -58,7 +58,7 @@ custom_rules:
     match_kinds:
     - identifier
     message: "Don't commit `print(…)`, `debugPrint(…)`, or `dump(…)` as they write to standard out in release. Either log to a dedicated logging system or silence this warning in debug-only scenarios explicitly using `// swiftlint:disable:next no_direct_standard_out_logs`"
-    severity: error
+    severity: warning
   no_file_literal:
     name: "#file is disallowed"
     regex: "(\\b#file\\b)"


### PR DESCRIPTION
#### Summary

Given we use print statements while developing, we don't want it to throw an error when we use them.

This got changed by the latest airbnb rule sync.

_Please react with 👍/👎 if you agree or disagree with this proposal._
